### PR TITLE
Add clear button to device search field

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,12 +117,17 @@
                            placeholder="Enter Device Number"
                            oninput="this.value = this.value.toUpperCase(); updateMainDeviceField(this.value); searchDeviceInLookup(this.value);"
                            style="flex: 1; padding: 8px 12px; border-radius: 4px; border: 1px solid var(--input-border); background: var(--input-bg); color: var(--text-color); font-size: 14px; box-sizing: border-box; height: 40px;">
-                    <button onclick="refreshDeviceLookup()" 
+                    <button onclick="refreshDeviceLookup()"
                             style="padding: 8px 12px; background: #1a73e8; color: white; border: none; border-radius: 4px; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: background-color 0.3s ease;"
                             title="Refresh Device Lookup">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z"/>
                         </svg>
+                    </button>
+                    <button onclick="clearDeviceLookup()"
+                            style="padding: 8px 12px; background: #ff6b6b; color: white; border: none; border-radius: 4px; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: background-color 0.3s ease;"
+                            title="Clear Device Lookup">
+                        ✕
                     </button>
                 </div>
                 <div id="quickDeviceResult" style="width: 100%; background: var(--result-bg); padding: 8px; border-radius: 4px; color: var(--text-color); min-height: 20px; border: 1px solid var(--input-border); box-sizing: border-box; overflow-wrap: break-word; word-break: break-word; font-size: 12px; display: none;"></div>
@@ -6855,6 +6860,17 @@
                 if (typeof lookupBIN === 'function') {
                     lookupBIN();
                 }
+            }
+        }
+
+        // Clear device lookup input and results
+        function clearDeviceLookup() {
+            const quickDeviceInput = document.getElementById('quickDeviceInput');
+            if (quickDeviceInput) {
+                quickDeviceInput.value = '';
+                quickDeviceInput.focus();
+                updateMainDeviceField('');
+                searchDeviceInLookup('');
             }
         }
 


### PR DESCRIPTION
## Summary
- add a clear button next to device search refresh
- implement `clearDeviceLookup` to reset field and results

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688acf1fd5f08325aa3f85183a21f9e7