### PR TITLE
Fix ELV3 checkbox parsing across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -17783,6 +17783,56 @@
         return result;
     }
 
+    function getCheckboxFieldInfo(fieldName) {
+        const pageMatch = fieldName.match(/Page(\d+)/i);
+        const checkboxMatch = fieldName.match(/CheckBox1(?:_|\[)(\d+)/i);
+
+        if (!checkboxMatch) {
+            return null;
+        }
+
+        return {
+            pageNum: pageMatch ? parseInt(pageMatch[1], 10) : null,
+            checkboxNum: parseInt(checkboxMatch[1], 10)
+        };
+    }
+
+    function mapCheckboxToDeviceStatus(fieldName) {
+        const checkboxInfo = getCheckboxFieldInfo(fieldName);
+        if (!checkboxInfo) {
+            return null;
+        }
+
+        const { pageNum, checkboxNum } = checkboxInfo;
+
+        if (pageNum && pageNum >= 2 && checkboxNum >= 34 && checkboxNum <= 43) {
+            const adjustedNum = checkboxNum - 34;
+            const pageOffset = (pageNum - 2) * 5;
+
+            return {
+                deviceIdx: pageOffset + (adjustedNum % 5) + 1,
+                isSatisfactory: adjustedNum < 5,
+                checkboxNum,
+                source: `Page${pageNum}`
+            };
+        }
+
+        if (checkboxNum >= 34 && checkboxNum <= 83) {
+            const adjustedNum = checkboxNum - 34;
+            const rowOf10 = Math.floor(adjustedNum / 10);
+            const posInRow = adjustedNum % 10;
+
+            return {
+                deviceIdx: (rowOf10 * 5) + (posInRow % 5) + 1,
+                isSatisfactory: posInRow < 5,
+                checkboxNum,
+                source: pageNum ? `Page${pageNum}` : 'UnknownPage'
+            };
+        }
+
+        return null;
+    }
+
     /**
      * Parse ELV3 form data into structured result
      * This is a direct port of the server's parseXFAFormFields function
@@ -17907,50 +17957,26 @@
         
         console.log('Total devices found:', Object.keys(devices).length, devices);
         
-        // Step 1b: Extract satisfactory/unsatisfactory status from Page1 checkboxes
-        // On Page1, devices are listed with Satisfactory and Unsatisfactory checkboxes
-        // Based on analysis:
-        // Devices 1-5:   SAT = 34-38,  UNSAT = 39-43
-        // Devices 6-10:  SAT = 44-48,  UNSAT = 49-53
-        // Devices 11-15: SAT = 54-58,  UNSAT = 59-63
-        // Devices 16-20: SAT = 64-68,  UNSAT = 69-73
-        // Devices 21-25: SAT = 74-78,  UNSAT = 79-83
+        // Step 1b: Extract satisfactory/unsatisfactory status from device checkboxes.
+        // Some ELV3 PDFs store the full device matrix on Page1 (checkboxes 34-83), while
+        // others repeat local checkbox numbers 34-43 on each device detail page.
         const deviceStatus = {}; // deviceIndex -> { satisfactory: bool, unsatisfactory: bool }
         
         for (const [fieldName, value] of Object.entries(formData)) {
-            if (!fieldName.includes('Page1')) continue;
-            
-            // Look for satisfactory checkbox pattern
-            const checkboxMatch = fieldName.match(/CheckBox1_(\d+)/);
-            if (checkboxMatch && value === true) {
-                const checkboxNum = parseInt(checkboxMatch[1]);
-                
-                // Determine which device row (0=devices 1-5, 1=devices 6-10, etc.)
-                // and whether it's SAT or UNSAT
-                // Pattern: Each row of 5 devices has 5 SAT checkboxes then 5 UNSAT checkboxes
-                // Row 0: 34-38 SAT, 39-43 UNSAT
-                // Row 1: 44-48 SAT, 49-53 UNSAT
-                // etc.
-                
-                if (checkboxNum >= 34) {
-                    const adjustedNum = checkboxNum - 34;
-                    const rowOf10 = Math.floor(adjustedNum / 10); // Each row has 10 checkboxes (5 SAT + 5 UNSAT)
-                    const posInRow = adjustedNum % 10;
-                    
-                    const isSatisfactory = posInRow < 5;
-                    const deviceInRow = posInRow < 5 ? posInRow : posInRow - 5;
-                    const deviceIdx = (rowOf10 * 5) + deviceInRow + 1;
-                    
-                    if (!deviceStatus[deviceIdx]) deviceStatus[deviceIdx] = {};
-                    
-                    if (isSatisfactory) {
-                        deviceStatus[deviceIdx].satisfactory = true;
-                        console.log(`Device ${deviceIdx} marked as SATISFACTORY (CheckBox1_${checkboxNum})`);
-                    } else {
-                        deviceStatus[deviceIdx].unsatisfactory = true;
-                        console.log(`Device ${deviceIdx} marked as UNSATISFACTORY (CheckBox1_${checkboxNum})`);
-                    }
-                }
+            if (value !== true) continue;
+
+            const checkboxInfo = mapCheckboxToDeviceStatus(fieldName);
+            if (!checkboxInfo) continue;
+
+            const { deviceIdx, isSatisfactory, checkboxNum, source } = checkboxInfo;
+            if (!deviceStatus[deviceIdx]) deviceStatus[deviceIdx] = {};
+
+            if (isSatisfactory) {
+                deviceStatus[deviceIdx].satisfactory = true;
+                console.log(`Device ${deviceIdx} marked as SATISFACTORY (${source} CheckBox1_${checkboxNum})`);
+            } else {
+                deviceStatus[deviceIdx].unsatisfactory = true;
+                console.log(`Device ${deviceIdx} marked as UNSATISFACTORY (${source} CheckBox1_${checkboxNum})`);
             }
         }
         

--- a/violation-tracker/server/services/elv3-parser.js
+++ b/violation-tracker/server/services/elv3-parser.js
@@ -289,6 +289,57 @@ async function extractFormFields(pdfBuffer) {
     return formData;
 }
 
+
+function getCheckboxFieldInfo(fieldName) {
+    const pageMatch = fieldName.match(/Page(\d+)/i);
+    const checkboxMatch = fieldName.match(/CheckBox1(?:_|\[)(\d+)/i);
+
+    if (!checkboxMatch) {
+        return null;
+    }
+
+    return {
+        pageNum: pageMatch ? parseInt(pageMatch[1], 10) : null,
+        checkboxNum: parseInt(checkboxMatch[1], 10)
+    };
+}
+
+function mapCheckboxToDeviceStatus(fieldName) {
+    const checkboxInfo = getCheckboxFieldInfo(fieldName);
+    if (!checkboxInfo) {
+        return null;
+    }
+
+    const { pageNum, checkboxNum } = checkboxInfo;
+
+    if (pageNum && pageNum >= 2 && checkboxNum >= 34 && checkboxNum <= 43) {
+        const adjustedNum = checkboxNum - 34;
+        const pageOffset = (pageNum - 2) * 5;
+
+        return {
+            deviceIdx: pageOffset + (adjustedNum % 5) + 1,
+            isSatisfactory: adjustedNum < 5,
+            checkboxNum,
+            source: `Page${pageNum}`
+        };
+    }
+
+    if (checkboxNum >= 34 && checkboxNum <= 83) {
+        const adjustedNum = checkboxNum - 34;
+        const rowOf10 = Math.floor(adjustedNum / 10);
+        const posInRow = adjustedNum % 10;
+
+        return {
+            deviceIdx: (rowOf10 * 5) + (posInRow % 5) + 1,
+            isSatisfactory: posInRow < 5,
+            checkboxNum,
+            source: pageNum ? `Page${pageNum}` : 'UnknownPage'
+        };
+    }
+
+    return null;
+}
+
 /**
  * Parse ELV3 form with XFA-style field names
  * Scans ALL pages (Page2, Page3, Page4, etc.) for devices and violations
@@ -411,50 +462,26 @@ function parseXFAFormFields(formData, result) {
     
     console.log('Total devices found:', Object.keys(devices).length, devices);
     
-    // Step 1b: Extract satisfactory/unsatisfactory status from Page1 checkboxes
-    // On Page1, devices are listed with Satisfactory and Unsatisfactory checkboxes
-    // Based on analysis:
-    // Devices 1-5:   SAT = 34-38,  UNSAT = 39-43
-    // Devices 6-10:  SAT = 44-48,  UNSAT = 49-53
-    // Devices 11-15: SAT = 54-58,  UNSAT = 59-63
-    // Devices 16-20: SAT = 64-68,  UNSAT = 69-73
-    // Devices 21-25: SAT = 74-78,  UNSAT = 79-83
+    // Step 1b: Extract satisfactory/unsatisfactory status from device checkboxes.
+    // Some ELV3 PDFs store the full device matrix on Page1 (checkboxes 34-83), while
+    // others repeat local checkbox numbers 34-43 on each device detail page.
     const deviceStatus = {}; // deviceIndex -> { satisfactory: bool, unsatisfactory: bool }
     
     for (const [fieldName, value] of Object.entries(formData)) {
-        if (!fieldName.includes('Page1')) continue;
-        
-        // Look for satisfactory checkbox pattern
-        const checkboxMatch = fieldName.match(/CheckBox1_(\d+)/);
-        if (checkboxMatch && value === true) {
-            const checkboxNum = parseInt(checkboxMatch[1]);
-            
-            // Determine which device row (0=devices 1-5, 1=devices 6-10, etc.)
-            // and whether it's SAT or UNSAT
-            // Pattern: Each row of 5 devices has 5 SAT checkboxes then 5 UNSAT checkboxes
-            // Row 0: 34-38 SAT, 39-43 UNSAT
-            // Row 1: 44-48 SAT, 49-53 UNSAT
-            // etc.
-            
-            if (checkboxNum >= 34) {
-                const adjustedNum = checkboxNum - 34;
-                const rowOf10 = Math.floor(adjustedNum / 10); // Each row has 10 checkboxes (5 SAT + 5 UNSAT)
-                const posInRow = adjustedNum % 10;
-                
-                const isSatisfactory = posInRow < 5;
-                const deviceInRow = posInRow < 5 ? posInRow : posInRow - 5;
-                const deviceIdx = (rowOf10 * 5) + deviceInRow + 1;
-                
-                if (!deviceStatus[deviceIdx]) deviceStatus[deviceIdx] = {};
-                
-                if (isSatisfactory) {
-                    deviceStatus[deviceIdx].satisfactory = true;
-                    console.log(`Device ${deviceIdx} marked as SATISFACTORY (CheckBox1_${checkboxNum})`);
-                } else {
-                    deviceStatus[deviceIdx].unsatisfactory = true;
-                    console.log(`Device ${deviceIdx} marked as UNSATISFACTORY (CheckBox1_${checkboxNum})`);
-                }
-            }
+        if (value !== true) continue;
+
+        const checkboxInfo = mapCheckboxToDeviceStatus(fieldName);
+        if (!checkboxInfo) continue;
+
+        const { deviceIdx, isSatisfactory, checkboxNum, source } = checkboxInfo;
+        if (!deviceStatus[deviceIdx]) deviceStatus[deviceIdx] = {};
+
+        if (isSatisfactory) {
+            deviceStatus[deviceIdx].satisfactory = true;
+            console.log(`Device ${deviceIdx} marked as SATISFACTORY (${source} CheckBox1_${checkboxNum})`);
+        } else {
+            deviceStatus[deviceIdx].unsatisfactory = true;
+            console.log(`Device ${deviceIdx} marked as UNSATISFACTORY (${source} CheckBox1_${checkboxNum})`);
         }
     }
     


### PR DESCRIPTION
### Motivation
- The ELV3 PDF upload was failing to recognize Satisfactory/Unsatisfactory checkboxes for devices shown on pages after Page1, causing devices on later pages to be treated as missing status.  
- ELV3 XFA forms use multiple checkbox name formats (underscore and bracket notation) and sometimes repeat local checkbox numbers on per-device pages, so a more robust mapping is needed.  
- Client-side (ELV3 tab) and server-side upload parsing must behave identically to avoid mismatches between preview and actual upload results.

### Description
- Added shared checkbox parsing helpers `getCheckboxFieldInfo(fieldName)` and `mapCheckboxToDeviceStatus(fieldName)` to the server parser at `violation-tracker/server/services/elv3-parser.js` and mirrored them in the client parser in `index.html`.  
- The helpers support both `CheckBox1_34` and `CheckBox1[34]` naming and return the inferred `pageNum`, `checkboxNum`, `deviceIdx`, and `isSatisfactory`, enabling consistent mapping from checkbox field names to device indices.  
- Replaced the previous Page1-only checkbox loop with logic that uses `mapCheckboxToDeviceStatus`, so checkboxes on Page2+ detail pages are mapped back to the correct global device index (5 devices per page offset logic) and full Page1 matrices (34-83) are still supported.  
- Kept client (`index.html`) and server parsers synchronized so both preview and upload use the same checkbox-handling behavior.

### Testing
- Ran `node --check violation-tracker/server/services/elv3-parser.js` to validate syntax; the check succeeded.  
- Executed a Node VM-based test that imports the updated parser and ran a set of mapping cases exercising Page1, Page2, and bracket/underscore checkbox name formats against `mapCheckboxToDeviceStatus`; all mapping cases passed.  
- No other automated parser integration tests were available in the repo; manual PDF parsing was used earlier for diagnosis but the automated mapping checks above are green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac215c8808325888d87b3b0709fdc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ELV3 parsing logic for mapping checkbox fields to device status; mistakes could misclassify devices as satisfactory/unsatisfactory across uploads and client previews.
> 
> **Overview**
> Fixes ELV3 device SAT/UNSAT detection for PDFs where the checkbox matrix is *not* confined to `Page1` and where field names use either underscore or bracket notation.
> 
> Adds shared-style helpers (`getCheckboxFieldInfo`, `mapCheckboxToDeviceStatus`) on both client (`index.html`) and server (`elv3-parser.js`) and replaces the previous `Page1`-only checkbox scan with a mapping-based scan that supports (a) full matrices (`CheckBox1` 34–83) and (b) per-device pages repeating checkbox numbers 34–43 (offset by page).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 243224dd3946b53fa69541c27bc3333369e923db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->