### PR TITLE
Fix ELV3 PDF parser: properly read satisfactory/unsatisfactory boxes on second page

### DIFF
--- a/violation-tracker/server/services/elv3-parser.js
+++ b/violation-tracker/server/services/elv3-parser.js
@@ -291,15 +291,23 @@ async function extractFormFields(pdfBuffer) {
 
 
 function getCheckboxFieldInfo(fieldName) {
-    const pageMatch = fieldName.match(/Page(\d+)/i);
-    const checkboxMatch = fieldName.match(/CheckBox1(?:_|\[)(\d+)/i);
+    // Use the LAST PageN occurrence - in nested forms (Page1.Page2.Page3), the checkbox
+    // belongs to the innermost page (Page3), not the first match (Page1)
+    const pageMatches = [...fieldName.matchAll(/Page(\d+)/gi)];
+    const pageNum = pageMatches.length > 0
+        ? parseInt(pageMatches[pageMatches.length - 1][1], 10)
+        : null;
+
+    // Support multiple checkbox naming patterns: CheckBox1_34, CheckBox1[34], CheckBox_34, CheckBox[34]
+    const checkboxMatch = fieldName.match(/CheckBox1?(?:_|\[)(\d+)/i)
+        || fieldName.match(/CheckBox[_\[](\d+)/i);
 
     if (!checkboxMatch) {
         return null;
     }
 
     return {
-        pageNum: pageMatch ? parseInt(pageMatch[1], 10) : null,
+        pageNum,
         checkboxNum: parseInt(checkboxMatch[1], 10)
     };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the issue where the ELV3 PDF upload/scan feature was not properly reading the satisfactory or unsatisfactory checkboxes for devices on the second page (ELV3A "Additional Devices" form).

## Root Causes

### 1. Page number extraction (first fix)
When field names had nested page references (e.g., `Page1.Page2.Page3.CheckBox1_34`), the code used the *first* `PageN` match instead of the last (innermost) one.

### 2. Checkbox pattern matching (first fix)
The regex only matched `CheckBox1_34` and `CheckBox1[34]`. Some PDFs use `CheckBox_34` or `CheckBox[34]`.

### 3. ELV3A Additional Devices page (second fix)
The ELV3A "Additional Devices" page has 11 devices (rows 6–16). The page-specific mapping only handled checkboxes 34–43 (5 devices). Checkboxes 44–54 for devices 11–16 fell through to the fallback, which uses a global layout and mapped them to the wrong devices (e.g., checkbox 44 → device 6 instead of device 11).

## Changes
- **Page extraction**: Use the *last* `PageN` occurrence in the field name.
- **Checkbox patterns**: Support `CheckBox_34`, `CheckBox[34]` in addition to `CheckBox1_34`, `CheckBox1[34]`.
- **ELV3A mapping**: Extend page-specific mapping to handle checkboxes 34–83 so all device rows on the Additional Devices page are mapped correctly.
- **Client parser**: Applied the same fixes to the client-side parser in `index.html` (used by the Scan ELV3 modal).

## Files Modified
- `violation-tracker/server/services/elv3-parser.js` – server-side parser
- `index.html` – client-side parser (Scan ELV3 feature)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0db8425-dae2-4c86-bda7-1fbc7140260c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0db8425-dae2-4c86-bda7-1fbc7140260c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

