### PR TITLE
Improve hydraulic device detection using machine_type field

### DIFF
--- a/index.html
+++ b/index.html
@@ -3101,32 +3101,39 @@
                     const hasPermits = permitResult.success && permitResult.permits && permitResult.permits.length > 0;
                     const permitData = permitResult;
 
+                    // Determine if device is hydraulic (CAT 5 not required)
+                    const deviceTypeLookup = (device.device_type || '').toUpperCase();
+                    const isHydraulic = deviceTypeLookup.includes('HYDRAULIC') || deviceTypeLookup.includes('HYDRO');
+
                     // Format dates and calculate most recent inspection
                     const cat1Date = device.cat1_latest_report_filed ? new Date(device.cat1_latest_report_filed) : null;
                     const cat5Date = device.cat5_latest_report_filed ? new Date(device.cat5_latest_report_filed) : null;
                     const pviDate = device.periodic_latest_inspection ? new Date(device.periodic_latest_inspection) : null;
-                    
-                    // Find most recent date
-                    const dates = [cat1Date, cat5Date, pviDate].filter(date => date !== null);
+
+                    // Find most recent date (exclude CAT 5 for hydraulic devices since it's not required)
+                    const dates = [cat1Date, isHydraulic ? null : cat5Date, pviDate].filter(date => date !== null);
                     const mostRecentDate = dates.length > 0 ? new Date(Math.max.apply(null, dates)) : null;
-                    
+
                     // Calculate days since most recent inspection
                     const today = new Date();
-                    const daysSinceInspection = mostRecentDate ? 
+                    const daysSinceInspection = mostRecentDate ?
                         Math.floor((today - mostRecentDate) / (1000 * 60 * 60 * 24)) : null;
-                    
+
                     // Format dates for display
                     const cat1Display = cat1Date ? cat1Date.toLocaleDateString() : 'N/A';
                     const cat5Display = cat5Date ? cat5Date.toLocaleDateString() : 'N/A';
                     const pviDisplay = pviDate ? pviDate.toLocaleDateString() : 'N/A';
                     const mostRecentDisplay = mostRecentDate ? mostRecentDate.toLocaleDateString() : 'N/A';
-                    
-                    // Check if all dates are the same (CAT 1, CAT 5, PVI, and Latest Inspection)
-                    const allDatesAreSame = cat1Date && cat5Date && pviDate && mostRecentDate &&
-                        cat1Date.getTime() === cat5Date.getTime() &&
-                        cat5Date.getTime() === pviDate.getTime() &&
-                        pviDate.getTime() === mostRecentDate.getTime();
-                    
+
+                    // Check if all dates are the same (data quality alert)
+                    // For hydraulic devices, only check CAT 1 and PVI (CAT 5 not required)
+                    const allDatesAreSame = isHydraulic
+                        ? (cat1Date && pviDate && cat1Date.getTime() === pviDate.getTime())
+                        : (cat1Date && cat5Date && pviDate && mostRecentDate &&
+                            cat1Date.getTime() === cat5Date.getTime() &&
+                            cat5Date.getTime() === pviDate.getTime() &&
+                            pviDate.getTime() === mostRecentDate.getTime());
+
                     // Apply red styling if all dates are the same
                     const dateStyle = allDatesAreSame ? 'color: red; font-weight: bold;' : '';
                     
@@ -3282,7 +3289,7 @@
                                 </div>
                                 <div style="margin-bottom: 10px;">
                                     <strong style="color: var(--header-color); display: inline-block; width: 120px;">Latest CAT 5:</strong> 
-                                    <span style="${dateStyle}">${cat5Display}</span>
+                                    ${isHydraulic ? '<span style="color: #888; font-style: italic;">Not required (Hydraulic)</span>' : '<span style="' + dateStyle + '">' + cat5Display + '</span>'}
                                 </div>
                                 <div style="margin-bottom: 10px;">
                                     <strong style="color: var(--header-color); display: inline-block; width: 120px;">Latest PVI:</strong> 
@@ -13502,11 +13509,7 @@
                                 </div>
                                 <div style="margin-bottom: 10px;">
                                     <strong style="color: var(--header-color); display: inline-block; width: 120px;">Latest CAT 5:</strong> 
-                                    <span style="${dateStyle}">${cat5Display}</span>
-                                </div>
-                                <div style="margin-bottom: 10px;">
-                                    <strong style="color: var(--header-color); display: inline-block; width: 120px;">Latest PVI:</strong> 
-                                    <span style="${dateStyle}">${pviDisplay}</span>
+                                    ${isHydraulic ? '<span style="color: #888; font-style: italic;">Not required (Hydraulic)</span>' : '<span style="' + dateStyle + '">' + cat5Display + '</span>'}
                                 </div>
                                 <div style="margin-bottom: 10px;">
                                     <strong style="color: var(--header-color); display: inline-block; width: 120px;">Latest Inspection:</strong> 
@@ -13604,32 +13607,39 @@
                     const hasPermits = permitResult.success && permitResult.permits && permitResult.permits.length > 0;
                     const permitData = permitResult;
 
+                    // Determine if device is hydraulic (CAT 5 not required)
+                    const deviceTypeLookup = (device.device_type || '').toUpperCase();
+                    const isHydraulic = deviceTypeLookup.includes('HYDRAULIC') || deviceTypeLookup.includes('HYDRO');
+
                     // Format dates and calculate most recent inspection
                     const cat1Date = device.cat1_latest_report_filed ? new Date(device.cat1_latest_report_filed) : null;
                     const cat5Date = device.cat5_latest_report_filed ? new Date(device.cat5_latest_report_filed) : null;
                     const pviDate = device.periodic_latest_inspection ? new Date(device.periodic_latest_inspection) : null;
-                    
-                    // Find most recent date
-                    const dates = [cat1Date, cat5Date, pviDate].filter(date => date !== null);
+
+                    // Find most recent date (exclude CAT 5 for hydraulic devices since it's not required)
+                    const dates = [cat1Date, isHydraulic ? null : cat5Date, pviDate].filter(date => date !== null);
                     const mostRecentDate = dates.length > 0 ? new Date(Math.max.apply(null, dates)) : null;
-                    
+
                     // Calculate days since most recent inspection
                     const today = new Date();
-                    const daysSinceInspection = mostRecentDate ? 
+                    const daysSinceInspection = mostRecentDate ?
                         Math.floor((today - mostRecentDate) / (1000 * 60 * 60 * 24)) : null;
-                    
+
                     // Format dates for display
                     const cat1Display = cat1Date ? cat1Date.toLocaleDateString() : 'N/A';
                     const cat5Display = cat5Date ? cat5Date.toLocaleDateString() : 'N/A';
                     const pviDisplay = pviDate ? pviDate.toLocaleDateString() : 'N/A';
                     const mostRecentDisplay = mostRecentDate ? mostRecentDate.toLocaleDateString() : 'N/A';
-                    
-                    // Check if all dates are the same (CAT 1, CAT 5, PVI, and Latest Inspection)
-                    const allDatesAreSame = cat1Date && cat5Date && pviDate && mostRecentDate &&
-                        cat1Date.getTime() === cat5Date.getTime() &&
-                        cat5Date.getTime() === pviDate.getTime() &&
-                        pviDate.getTime() === mostRecentDate.getTime();
-                    
+
+                    // Check if all dates are the same (data quality alert)
+                    // For hydraulic devices, only check CAT 1 and PVI (CAT 5 not required)
+                    const allDatesAreSame = isHydraulic
+                        ? (cat1Date && pviDate && cat1Date.getTime() === pviDate.getTime())
+                        : (cat1Date && cat5Date && pviDate && mostRecentDate &&
+                            cat1Date.getTime() === cat5Date.getTime() &&
+                            cat5Date.getTime() === pviDate.getTime() &&
+                            pviDate.getTime() === mostRecentDate.getTime());
+
                     // Apply red styling if all dates are the same
                     const dateStyle = allDatesAreSame ? 'color: red; font-weight: bold;' : '';
                     

--- a/index.html
+++ b/index.html
@@ -11802,7 +11802,9 @@
                     const isDumwaiter = device.device_type && device.device_type.toUpperCase().includes('DUMWAITER');
                     const isConveyor = device.device_type && device.device_type.toUpperCase().includes('CONVEYOR');
                     const isWheelchairLift = device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR');
-                    const isHydraulic = device.device_type && (device.device_type.toUpperCase().includes('HYDRAULIC') || device.device_type.toUpperCase().includes('HYDRO'));
+                    const binMachineTypeUpper = (deviceInfo?.machine_type || '').toUpperCase();
+                    const isHydraulic = (device.device_type && (device.device_type.toUpperCase().includes('HYDRAULIC') || device.device_type.toUpperCase().includes('HYDRO'))) ||
+                                        binMachineTypeUpper.includes('HYDRAULIC') || binMachineTypeUpper.includes('HYDRO');
                     const isEscalator = device.device_type && device.device_type.toUpperCase().includes('ESCALATOR');
                     let requiresCat5 = false;
                     if (!isDumwaiter && !isConveyor && !isWheelchairLift && !isHydraulic && !isEscalator && cat5Date) {
@@ -12065,14 +12067,17 @@
                         devicePromises.push((async () => {
                             // Fetch violations for this device
                             const violations = await fetchViolations(device.device_number);
-                            const activeViolations = violations.filter(v => 
-                                v.violation_status?.toUpperCase() === 'ACTIVE' || 
+                            const activeViolations = violations.filter(v =>
+                                v.violation_status?.toUpperCase() === 'ACTIVE' ||
                                 v.violation_status?.toUpperCase() === 'OPEN');
-                            
+
+                            // Fetch device info (for machine_type hydraulic check)
+                            const deviceInfo = await fetchDeviceInfo(device.device_number);
+
                             // Fetch permit information for this device
                             const permitData = await fetchPermitInfo(device.device_number);
                             const permits = (permitData.success && permitData.permits) ? permitData.permits : [];
-                            
+
                             // Format permit details
                             const permitNumbers = permits.map(p => p.permit_number || p.job_filing_number || 'N/A').join('; ');
                             const permitIssueDates = permits.map(p => {
@@ -12115,16 +12120,18 @@
                             
                             // Check device type and status
                             const deviceType = (device.device_type || '').toUpperCase();
+                            const machineTypeUpper = (deviceInfo?.machine_type || '').toUpperCase();
                             const deviceStatus = (device.device_status || '').toUpperCase();
                             const isDismantled = deviceStatus.includes('DISMANTLED');
                             const isRemoved = deviceStatus.includes('REMOVED') || deviceStatus.includes('DELETED');
                             const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                             const isConveyor = deviceType.includes('CONVEYOR');
                             const isWheelchairLift = deviceType.includes('WHEELCHAIR');
-                            const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO');
+                            const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
+                                                machineTypeUpper.includes('HYDRAULIC') || machineTypeUpper.includes('HYDRO');
                             const isEscalator = deviceType.includes('ESCALATOR');
                             const cat5NotApplicable = isDumbwaiter || isConveyor || isWheelchairLift || isHydraulic || isEscalator || isDismantled || isRemoved;
-                            
+
                             let requiresCat5 = false;
                             let nextCat5Due = 'N/A';
                             if (!isDumbwaiter && !isConveyor && !isWheelchairLift && !isHydraulic && !isEscalator && cat5Date) {
@@ -12136,7 +12143,7 @@
                             } else {
                                 nextCat5Due = 'No CAT 5 on file';
                             }
-                            
+
                             // Determine test status
                             let testStatus;
                             if (isRemoved) {
@@ -12208,8 +12215,8 @@
                                 cat5Date.getTime() === pviDate.getTime();
                             
                             // Get missed required tests
-                            const missedTests = getMissedRequiredTests(device);
-                            
+                            const missedTests = getMissedRequiredTests(device, deviceInfo?.machine_type);
+
                             // Check for removal permits
                             let hasRemovalPermit = false;
                             let removalPermitNumber = '';
@@ -12218,7 +12225,7 @@
                                     const workType = (p.work_type || '').toUpperCase();
                                     const description = (p.description || '').toUpperCase();
                                     const appType = (p.application_type || '').toUpperCase();
-                                    return workType.includes('REMOVAL') || workType.includes('REMOVE') || 
+                                    return workType.includes('REMOVAL') || workType.includes('REMOVE') ||
                                            workType.includes('DISMANTLE') || workType.includes('DISCONTINUE') ||
                                            description.includes('REMOVAL') || description.includes('REMOVE ELEVATOR') ||
                                            description.includes('DISMANTLE') || description.includes('DISCONTINUE') ||
@@ -12229,7 +12236,7 @@
                                     removalPermitNumber = removalPermit.permit_number || removalPermit.job_filing_number || '';
                                 }
                             }
-                            
+
                             // Build important info string
                             let importantInfoParts = [];
                             if (allDatesAreSame) {
@@ -12510,6 +12517,9 @@
                                 v.violation_status?.toUpperCase() === 'ACTIVE' || 
                                 v.violation_status?.toUpperCase() === 'OPEN');
                             
+
+                            // Fetch device info (for machine_type hydraulic check)
+                            const deviceInfo = await fetchDeviceInfo(device.device_number);
                             // Format violation details (same format as BIN export)
                             const violationNumbers = activeViolations.map(v => v.violation_number || 'N/A').join('; ');
                             const violationIssueDates = activeViolations.map(v => {
@@ -12557,13 +12567,15 @@
                             
                             // Check device type and status (DELETED is treated as REMOVED)
                             const deviceType = (device.device_type || '').toUpperCase();
+                            const machineTypeUpper = (deviceInfo?.machine_type || '').toUpperCase();
                             const deviceStatus = (device.device_status || '').toUpperCase();
                             const isDismantled = deviceStatus.includes('DISMANTLED');
                             const isRemoved = deviceStatus.includes('REMOVED') || deviceStatus.includes('DELETED');
                             const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                             const isConveyor = deviceType.includes('CONVEYOR');
                             const isWheelchairLift = deviceType.includes('WHEELCHAIR');
-                            const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO');
+                            const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
+                                                machineTypeUpper.includes('HYDRAULIC') || machineTypeUpper.includes('HYDRO');
                             const isEscalator = deviceType.includes('ESCALATOR');
                             const cat5NotApplicable = isDumbwaiter || isConveyor || isWheelchairLift || isHydraulic || isEscalator || isDismantled || isRemoved;
                             
@@ -12657,8 +12669,8 @@
                                 cat5Date.getTime() === pviDate.getTime();
                             
                             // Get missed required tests
-                            const missedTests = getMissedRequiredTests(device);
-                            
+                            const missedTests = getMissedRequiredTests(device, deviceInfo?.machine_type);
+
                             // Check for removal permits
                             let hasRemovalPermit = false;
                             let removalPermitNumber = '';
@@ -12667,7 +12679,7 @@
                                     const workType = (p.work_type || '').toUpperCase();
                                     const description = (p.description || '').toUpperCase();
                                     const appType = (p.application_type || '').toUpperCase();
-                                    return workType.includes('REMOVAL') || workType.includes('REMOVE') || 
+                                    return workType.includes('REMOVAL') || workType.includes('REMOVE') ||
                                            workType.includes('DISMANTLE') || workType.includes('DISCONTINUE') ||
                                            description.includes('REMOVAL') || description.includes('REMOVE ELEVATOR') ||
                                            description.includes('DISMANTLE') || description.includes('DISCONTINUE') ||
@@ -12678,7 +12690,7 @@
                                     removalPermitNumber = removalPermit.permit_number || removalPermit.job_filing_number || '';
                                 }
                             }
-                            
+
                             // Build important info string
                             let importantInfoParts = [];
                             if (allDatesAreSame) {

--- a/index.html
+++ b/index.html
@@ -1512,21 +1512,23 @@
         }
 
         // Function to check for missed required tests in prior years
-        function getMissedRequiredTests(device) {
+        function getMissedRequiredTests(device, machineType = '') {
             const missedTests = [];
             const currentYear = new Date().getFullYear();
-            
+
             // Get all test dates
             const cat1Date = device.cat1_latest_report_filed ? new Date(device.cat1_latest_report_filed) : null;
             const cat5Date = device.cat5_latest_report_filed ? new Date(device.cat5_latest_report_filed) : null;
             const pviDate = device.periodic_latest_inspection ? new Date(device.periodic_latest_inspection) : null;
-            
+
             // Check device type for test requirements
             const deviceType = (device.device_type || '').toUpperCase();
+            const machineTypeUpper = (machineType || '').toUpperCase();
             const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMWAITER');
             const isConveyor = deviceType.includes('CONVEYOR');
             const isWheelchairLift = deviceType.includes('WHEELCHAIR');
-            const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO');
+            const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
+                                 machineTypeUpper.includes('HYDRAULIC') || machineTypeUpper.includes('HYDRO');
             const isEscalator = deviceType.includes('ESCALATOR');
             
             // Skip if device is removed or deleted
@@ -3339,7 +3341,7 @@
                             
                             <!-- Add Important dropdown for missed required tests -->
                             ${(() => {
-                                const missedTests = getMissedRequiredTests(device);
+                                const missedTests = getMissedRequiredTests(device, deviceInfo?.machine_type);
                                 if (missedTests.length > 0) {
                                     // Check if device has a removal permit
                                     let hasRemovalPermit = false;
@@ -13845,7 +13847,7 @@
                             
                             <!-- Add Important dropdown for missed required tests -->
                             ${(() => {
-                                const missedTests = getMissedRequiredTests(device);
+                                const missedTests = getMissedRequiredTests(device, deviceInfo?.machine_type);
                                 if (missedTests.length > 0) {
                                     // Check if device has a removal permit
                                     let hasRemovalPermit = false;


### PR DESCRIPTION
## Summary
Enhanced hydraulic device detection to check both the `device_type` and `machine_type` fields, ensuring CAT 5 inspection requirements are correctly identified for hydraulic elevators that may only be classified in the machine_type field.

## Key Changes
- **Updated `getMissedRequiredTests()` function** to accept an optional `machineType` parameter and check it for hydraulic classification alongside device_type
- **Enhanced hydraulic detection logic** across multiple code sections to check both `device_type` and `machine_type` fields for 'HYDRAULIC' or 'HYDRO' keywords
- **Improved CAT 5 handling for hydraulic devices**:
  - Exclude CAT 5 dates from "most recent inspection" calculations for hydraulic devices
  - Updated data quality alert logic to only compare CAT 1 and PVI dates for hydraulic devices (since CAT 5 is not required)
  - Display "Not required (Hydraulic)" message instead of CAT 5 date for hydraulic devices
- **Added `deviceInfo` fetching** in export functions to access the `machine_type` field for hydraulic classification
- **Updated all calls to `getMissedRequiredTests()`** to pass the `machine_type` parameter from device info

## Implementation Details
- The changes maintain backward compatibility by using optional parameters and default values
- Hydraulic detection now uses a two-source approach: checks both device_type field and machine_type field
- Data quality alerts (red highlighting for identical dates) now account for device type, avoiding false positives for hydraulic devices where CAT 5 is not applicable
- Consistent formatting applied across multiple report sections (BIN export, detailed views, etc.)

https://claude.ai/code/session_01VoJF8ZoxngT5xy9r6Cvskd