### PR TITLE
Add hydraulic device note in Search by Device Number and Search by BIN

### DIFF
--- a/index.html
+++ b/index.html
@@ -3105,7 +3105,9 @@
 
                     // Determine if device is hydraulic (CAT 5 not required)
                     const deviceTypeLookup = (device.device_type || '').toUpperCase();
-                    const isHydraulic = deviceTypeLookup.includes('HYDRAULIC') || deviceTypeLookup.includes('HYDRO');
+                    const machineTypeLookup = (deviceInfo?.machine_type || '').toUpperCase();
+                    const isHydraulic = deviceTypeLookup.includes('HYDRAULIC') || deviceTypeLookup.includes('HYDRO') ||
+                                        machineTypeLookup.includes('HYDRAULIC') || machineTypeLookup.includes('HYDRO');
 
                     // Format dates and calculate most recent inspection
                     const cat1Date = device.cat1_latest_report_filed ? new Date(device.cat1_latest_report_filed) : null;
@@ -3339,6 +3341,13 @@
                                 </div>
                             ` : ''}
                             
+                            <!-- Hydraulic note -->
+                            ${isHydraulic ? `
+                                <div style="margin-top: 10px; padding: 10px 14px; background: rgba(26, 115, 232, 0.08); border: 1px solid rgba(26, 115, 232, 0.3); border-radius: 6px; color: var(--text-color); font-size: 0.9em;">
+                                    ℹ️ <strong>Hydraulic Device:</strong> This machine type is listed as Hydraulic on the DOB. No CAT 5 testing is required.
+                                </div>
+                            ` : ''}
+
                             <!-- Add Important dropdown for missed required tests -->
                             ${(() => {
                                 const missedTests = getMissedRequiredTests(device, deviceInfo?.machine_type);
@@ -7289,6 +7298,11 @@
                                                             This device is highlighted in red because all three inspection dates (CAT 1, CAT 5, and PVI) are identical. This may indicate that an acceptance test was performed on this device. If acceptance test was performed no additional inspection test are required for that calendar year. Please check the official DOB site to verify the legitimacy of this information.
                                                         </div>
                                                     </div>
+                                                </div>
+                                            ` : ''}
+                                            ${isHydraulic ? `
+                                                <div style="margin-top: 8px; padding: 8px 12px; background: rgba(26, 115, 232, 0.08); border: 1px solid rgba(26, 115, 232, 0.3); border-radius: 6px; color: var(--text-color); font-size: 0.85em;">
+                                                    ℹ️ <strong>Hydraulic Device:</strong> This machine type is listed as Hydraulic on the DOB. No CAT 5 testing is required.
                                                 </div>
                                             ` : ''}
                                             ${(() => {
@@ -13629,7 +13643,9 @@
 
                     // Determine if device is hydraulic (CAT 5 not required)
                     const deviceTypeLookup = (device.device_type || '').toUpperCase();
-                    const isHydraulic = deviceTypeLookup.includes('HYDRAULIC') || deviceTypeLookup.includes('HYDRO');
+                    const machineTypeLookup = (deviceInfo?.machine_type || '').toUpperCase();
+                    const isHydraulic = deviceTypeLookup.includes('HYDRAULIC') || deviceTypeLookup.includes('HYDRO') ||
+                                        machineTypeLookup.includes('HYDRAULIC') || machineTypeLookup.includes('HYDRO');
 
                     // Format dates and calculate most recent inspection
                     const cat1Date = device.cat1_latest_report_filed ? new Date(device.cat1_latest_report_filed) : null;
@@ -13863,6 +13879,13 @@
                                 </div>
                             ` : ''}
                             
+                            <!-- Hydraulic note -->
+                            ${isHydraulic ? `
+                                <div style="margin-top: 10px; padding: 10px 14px; background: rgba(26, 115, 232, 0.08); border: 1px solid rgba(26, 115, 232, 0.3); border-radius: 6px; color: var(--text-color); font-size: 0.9em;">
+                                    ℹ️ <strong>Hydraulic Device:</strong> This machine type is listed as Hydraulic on the DOB. No CAT 5 testing is required.
+                                </div>
+                            ` : ''}
+
                             <!-- Add Important dropdown for missed required tests -->
                             ${(() => {
                                 const missedTests = getMissedRequiredTests(device, deviceInfo?.machine_type);


### PR DESCRIPTION
## Summary

- Displays an info banner on hydraulic devices in both **Search by Device Number** and **Search by BIN** outputs:
  > ℹ️ **Hydraulic Device:** This machine type is listed as Hydraulic on the DOB. No CAT 5 testing is required.
- The banner triggers when either `device_type` or `machine_type` indicates hydraulic
- Also extends the `isHydraulic` check in both device lookup contexts to include `deviceInfo.machine_type`

## Test plan
- [ ] Look up a hydraulic device by device number — confirm the blue info banner appears
- [ ] Search by BIN for a building with hydraulic devices — confirm the banner appears on each hydraulic device card
- [ ] Confirm non-hydraulic devices do not show the banner

https://claude.ai/code/session_01VoJF8ZoxngT5xy9r6Cvskd