### PR TITLE
Extend hydraulic fixes and note to Bulk Device Lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -7843,7 +7843,11 @@
                         
                         // Store violations with device
                         device.violations = activeViolations;
-                        
+
+                        // Fetch and store machine_type for hydraulic detection
+                        const bulkDeviceInfo = await fetchDeviceInfo(deviceNumber);
+                        device.machine_type = bulkDeviceInfo?.machine_type || null;
+
                         if (!binGroups[bin]) {
                             binGroups[bin] = {
                                 address: `${device.house_number} ${device.street_name}, ${device.borough}`,
@@ -8037,7 +8041,9 @@
                     const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                     const isConveyor = deviceType.includes('CONVEYOR');
                     const isWheelchairLift = deviceType.includes('WHEELCHAIR');
-                    const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO');
+                    const calcMachineTypeUpper = (d.machine_type || '').toUpperCase();
+                    const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
+                                        calcMachineTypeUpper.includes('HYDRAULIC') || calcMachineTypeUpper.includes('HYDRO');
                     const isEscalator = deviceType.includes('ESCALATOR');
                     const noTestRequired = isRemoved;
                     
@@ -8238,9 +8244,11 @@
                         const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                         const isConveyor = deviceType.includes('CONVEYOR');
                         const isWheelchairLift = deviceType.includes('WHEELCHAIR');
-                        const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO');
+                        const bulkMachineTypeUpper = (device.machine_type || '').toUpperCase();
+                        const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
+                                            bulkMachineTypeUpper.includes('HYDRAULIC') || bulkMachineTypeUpper.includes('HYDRO');
                         const isEscalator = deviceType.includes('ESCALATOR');
-                        
+
                         // Removed/deleted devices don't require any tests
                         if (isRemoved) {
                             devicesNoTestRequired++;
@@ -9019,8 +9027,21 @@
                             `;
                         }
                         
+                        // Add hydraulic note row
+                        if (isHydraulic) {
+                            html += `
+                                <tr style="background: ${rowBg};">
+                                    <td colspan="11" style="padding: 0; border: 1px solid var(--input-border);">
+                                        <div style="padding: 8px 12px; background: rgba(26, 115, 232, 0.08); border-left: 3px solid rgba(26, 115, 232, 0.5); color: var(--text-color); font-size: 0.88em;">
+                                            ℹ️ <strong>Hydraulic Device:</strong> This machine type is listed as Hydraulic on the DOB. No CAT 5 testing is required.
+                                        </div>
+                                    </td>
+                                </tr>
+                            `;
+                        }
+
                         // Add Important dropdown row for missed required tests
-                        const missedTests = getMissedRequiredTests(device);
+                        const missedTests = getMissedRequiredTests(device, device.machine_type);
                         if (missedTests.length > 0) {
                             // Check for removal permits for this device
                             let removalPermitNote = '';


### PR DESCRIPTION
## Summary

- **Bulk Device Lookup** now fetches `deviceInfo` per device during the lookup phase and stores `machine_type` on the device object
- `isHydraulic` in the stats loop and `calculateDeviceInfo` helper now check `device.machine_type` in addition to `device_type`
- `getMissedRequiredTests` receives `device.machine_type` so CAT 5 missed test alert is suppressed for hydraulic devices
- Hydraulic note banner added to each device row in the bulk lookup table: "This machine type is listed as Hydraulic on the DOB. No CAT 5 testing is required."

## Test plan
- [ ] Run a Bulk Device Lookup with a hydraulic device — confirm the blue info banner appears in its row
- [ ] Confirm no "Missed Required Test" alert appears for hydraulic devices in the bulk results
- [ ] Confirm non-hydraulic devices are unaffected

https://claude.ai/code/session_01VoJF8ZoxngT5xy9r6Cvskd