### PR TITLE
Recognize device numbers with 'W' as wheelchair lifts to suppress CAT 5 warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1515,7 +1515,8 @@
             const machineTypeUpper = (machineType || '').toUpperCase();
             const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMWAITER');
             const isConveyor = deviceType.includes('CONVEYOR');
-            const isWheelchairLift = deviceType.includes('WHEELCHAIR');
+            const deviceNumberUpper = (device.device_number || '').toUpperCase();
+            const isWheelchairLift = deviceType.includes('WHEELCHAIR') || deviceNumberUpper.includes('W');
             const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
                                  machineTypeUpper.includes('HYDRAULIC') || machineTypeUpper.includes('HYDRO');
             const isEscalator = deviceType.includes('ESCALATOR');
@@ -5648,7 +5649,8 @@
                         const isDismantled = device.device_status && device.device_status.toUpperCase() === 'DISMANTLED';
                         const isDumwaiter = device.device_type && device.device_type.toUpperCase().includes('DUMWAITER');
                         const isConveyor = device.device_type && device.device_type.toUpperCase().includes('CONVEYOR');
-                        const isWheelchairLift = device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR');
+                        const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                        const isWheelchairLift = (device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR')) || deviceNumberUpper.includes('W');
                         const isHydraulic = device.device_type && (device.device_type.toUpperCase().includes('HYDRAULIC') || device.device_type.toUpperCase().includes('HYDRO'));
                         const isEscalator = device.device_type && device.device_type.toUpperCase().includes('ESCALATOR');
                         const hasPVIThisYear = pviDate && pviDate.getFullYear() === currentYearForEligibility;
@@ -5720,7 +5722,8 @@
                         // Check if this is a warning device (CAT 1 & PVI done but CAT 5 required and not done)
                         const isDumwaiter = device.device_type && device.device_type.toUpperCase().includes('DUMWAITER');
                         const isConveyor = device.device_type && device.device_type.toUpperCase().includes('CONVEYOR');
-                        const isWheelchairLift = device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR');
+                        const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                        const isWheelchairLift = (device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR')) || deviceNumberUpper.includes('W');
                         const isHydraulic = device.device_type && (device.device_type.toUpperCase().includes('HYDRAULIC') || device.device_type.toUpperCase().includes('HYDRO'));
                         const isEscalator = device.device_type && device.device_type.toUpperCase().includes('ESCALATOR');
                         const hasPVIThisYear = pviDate && pviDate.getFullYear() === currentYearForEligibility;
@@ -5831,7 +5834,8 @@
                         // Dumbwaiters, Conveyors, Wheelchair Lifts, Hydraulic elevators, and Escalators do not need CAT 5 testing
                         const isDumwaiter = device.device_type && device.device_type.toUpperCase().includes('DUMWAITER');
                         const isConveyor = device.device_type && device.device_type.toUpperCase().includes('CONVEYOR');
-                        const isWheelchairLift = device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR');
+                        const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                        const isWheelchairLift = (device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR')) || deviceNumberUpper.includes('W');
                         const isHydraulic = device.device_type && (device.device_type.toUpperCase().includes('HYDRAULIC') || device.device_type.toUpperCase().includes('HYDRO'));
                         const isEscalator = device.device_type && device.device_type.toUpperCase().includes('ESCALATOR');
                         let requiresCat5 = false;
@@ -6625,7 +6629,8 @@
             // Dumbwaiters, Conveyors, Wheelchair Lifts, Hydraulic elevators, and Escalators do not need CAT 5 testing
             const isDumwaiter = device.device_type && device.device_type.toUpperCase().includes('DUMWAITER');
             const isConveyor = device.device_type && device.device_type.toUpperCase().includes('CONVEYOR');
-            const isWheelchairLift = device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR');
+            const deviceNumberUpper = (device.device_number || '').toUpperCase();
+            const isWheelchairLift = (device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR')) || deviceNumberUpper.includes('W');
             const isHydraulic = device.device_type && (device.device_type.toUpperCase().includes('HYDRAULIC') || device.device_type.toUpperCase().includes('HYDRO'));
             const isEscalator = device.device_type && device.device_type.toUpperCase().includes('ESCALATOR');
             let requiresCat5 = false;
@@ -6781,7 +6786,8 @@
                                 // Check if CAT 5 is required this year (Dumbwaiters, Conveyors, Wheelchair Lifts, Hydraulic elevators, and Escalators do not need CAT 5 testing)
                                 const isDumwaiter = device.device_type && device.device_type.toUpperCase().includes('DUMWAITER');
                                 const isConveyor = device.device_type && device.device_type.toUpperCase().includes('CONVEYOR');
-                                const isWheelchairLift = device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR');
+                                const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                                const isWheelchairLift = (device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR')) || deviceNumberUpper.includes('W');
                                 const isHydraulic = (device.device_type && (device.device_type.toUpperCase().includes('HYDRAULIC') || device.device_type.toUpperCase().includes('HYDRO'))) ||
                                                    itemMachineTypeUpper.includes('HYDRAULIC') || itemMachineTypeUpper.includes('HYDRO');
                                 const isEscalator = device.device_type && device.device_type.toUpperCase().includes('ESCALATOR');
@@ -7501,7 +7507,8 @@
                     // Determine device type before date calculations (needed for hydraulic exclusion)
                     const isDumwaiter = device.device_type && device.device_type.toUpperCase().includes('DUMWAITER');
                     const isConveyor = device.device_type && device.device_type.toUpperCase().includes('CONVEYOR');
-                    const isWheelchairLift = device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR');
+                    const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                    const isWheelchairLift = (device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR')) || deviceNumberUpper.includes('W');
                     const csvMachineTypeUpper = (deviceInfo?.machine_type || '').toUpperCase();
                     const isHydraulic = (device.device_type && (device.device_type.toUpperCase().includes('HYDRAULIC') || device.device_type.toUpperCase().includes('HYDRO'))) ||
                                         csvMachineTypeUpper.includes('HYDRAULIC') || csvMachineTypeUpper.includes('HYDRO');
@@ -7913,7 +7920,8 @@
                         const isRemoved = deviceStatus.includes('REMOVED') || deviceStatus.includes('DELETED');
                         const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                         const isConveyor = deviceType.includes('CONVEYOR');
-                        const isWheelchairLift = deviceType.includes('WHEELCHAIR');
+                        const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                        const isWheelchairLift = deviceType.includes('WHEELCHAIR') || deviceNumberUpper.includes('W');
                         const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
                                             machineTypeUpper.includes('HYDRAULIC') || machineTypeUpper.includes('HYDRO');
                         const isEscalator = deviceType.includes('ESCALATOR');
@@ -8044,7 +8052,8 @@
                     const isRemoved = deviceStatus.includes('REMOVED') || deviceStatus.includes('DELETED');
                     const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                     const isConveyor = deviceType.includes('CONVEYOR');
-                    const isWheelchairLift = deviceType.includes('WHEELCHAIR');
+                    const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                    const isWheelchairLift = deviceType.includes('WHEELCHAIR') || deviceNumberUpper.includes('W');
                     const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
                                         machineTypeUpper.includes('HYDRAULIC') || machineTypeUpper.includes('HYDRO');
                     const isEscalator = deviceType.includes('ESCALATOR');
@@ -8247,7 +8256,8 @@
                         const isRemoved = deviceStatus.includes('REMOVED') || deviceStatus.includes('DELETED');
                         const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                         const isConveyor = deviceType.includes('CONVEYOR');
-                        const isWheelchairLift = deviceType.includes('WHEELCHAIR');
+                        const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                        const isWheelchairLift = deviceType.includes('WHEELCHAIR') || deviceNumberUpper.includes('W');
                         const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
                                             machineTypeUpper.includes('HYDRAULIC') || machineTypeUpper.includes('HYDRO');
                         const isEscalator = deviceType.includes('ESCALATOR');
@@ -8846,7 +8856,8 @@
                         const isRemoved = deviceStatus.includes('REMOVED') || deviceStatus.includes('DELETED');
                         const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                         const isConveyor = deviceType.includes('CONVEYOR');
-                        const isWheelchairLift = deviceType.includes('WHEELCHAIR');
+                        const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                        const isWheelchairLift = deviceType.includes('WHEELCHAIR') || deviceNumberUpper.includes('W');
                         const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
                                             bulkMachineType.includes('HYDRAULIC') || bulkMachineType.includes('HYDRO');
                         const isEscalator = deviceType.includes('ESCALATOR');
@@ -9790,7 +9801,8 @@
                 const isRemoved = deviceStatus.includes('REMOVED') || deviceStatus.includes('DELETED');
                 const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER');
                 const isConveyor = deviceType.includes('CONVEYOR');
-                const isWheelchairLift = deviceType.includes('WHEELCHAIR');
+                const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                const isWheelchairLift = deviceType.includes('WHEELCHAIR') || deviceNumberUpper.includes('W');
                 const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
                                     popupMachineType.includes('HYDRAULIC') || popupMachineType.includes('HYDRO');
                 const isEscalator = deviceType.includes('ESCALATOR');
@@ -11629,7 +11641,8 @@
                     // Check if category test was done this year
                     const isDumwaiter = device.device_type && device.device_type.toUpperCase().includes('DUMWAITER');
                     const isConveyor = device.device_type && device.device_type.toUpperCase().includes('CONVEYOR');
-                    const isWheelchairLift = device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR');
+                    const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                    const isWheelchairLift = (device.device_type && device.device_type.toUpperCase().includes('WHEELCHAIR')) || deviceNumberUpper.includes('W');
                     const binMachineTypeUpper = (deviceInfo?.machine_type || '').toUpperCase();
                     const isHydraulic = (device.device_type && (device.device_type.toUpperCase().includes('HYDRAULIC') || device.device_type.toUpperCase().includes('HYDRO'))) ||
                                         binMachineTypeUpper.includes('HYDRAULIC') || binMachineTypeUpper.includes('HYDRO');
@@ -11964,7 +11977,8 @@
                             const isRemoved = deviceStatus.includes('REMOVED') || deviceStatus.includes('DELETED');
                             const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                             const isConveyor = deviceType.includes('CONVEYOR');
-                            const isWheelchairLift = deviceType.includes('WHEELCHAIR');
+                            const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                            const isWheelchairLift = deviceType.includes('WHEELCHAIR') || deviceNumberUpper.includes('W');
                             const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
                                                 machineTypeUpper.includes('HYDRAULIC') || machineTypeUpper.includes('HYDRO');
                             const isEscalator = deviceType.includes('ESCALATOR');
@@ -12411,7 +12425,8 @@
                             const isRemoved = deviceStatus.includes('REMOVED') || deviceStatus.includes('DELETED');
                             const isDumbwaiter = deviceType.includes('DUMBWAITER') || deviceType.includes('DUMB WAITER') || deviceType.includes('DUMWAITER');
                             const isConveyor = deviceType.includes('CONVEYOR');
-                            const isWheelchairLift = deviceType.includes('WHEELCHAIR');
+                            const deviceNumberUpper = (device.device_number || '').toUpperCase();
+                            const isWheelchairLift = deviceType.includes('WHEELCHAIR') || deviceNumberUpper.includes('W');
                             const isHydraulic = deviceType.includes('HYDRAULIC') || deviceType.includes('HYDRO') ||
                                                 machineTypeUpper.includes('HYDRAULIC') || machineTypeUpper.includes('HYDRO');
                             const isEscalator = deviceType.includes('ESCALATOR');


### PR DESCRIPTION
### Motivation
- Wheelchair lift devices were being flagged as requiring CAT 5 when their `device_type` text did not explicitly include "WHEELCHAIR", but their `device_number` contains a `W` which should identify them as wheelchair lifts. 

### Description
- Update: `index.html` now computes `deviceNumberUpper = (device.device_number || '').toUpperCase()` and treats `isWheelchairLift` as true when either `device_type` contains `WHEELCHAIR` or `deviceNumberUpper` includes `W`, preserving existing `device_type` checks. 
- Applied this `device_number`-based wheelchair lift rule consistently across DOB result and status logic paths (missed tests, eligibility/warning calculations, popup/device lists, CSV export and summary generation) so those devices are excluded from CAT 5 required warnings. 
- Changes were saved and committed to the branch (updated `index.html` with the new detection logic). 

### Testing
- Ran `git -C /workspace/ELV3 diff --check` to validate the patch formatting and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cade29fd1483258a9511c1d37ec387)